### PR TITLE
fix(altkey): agregar ON OVERFLOW al STRING y traducir mensajes al español

### DIFF
--- a/samples/altkey/altkey.cob
+++ b/samples/altkey/altkey.cob
@@ -327,20 +327,17 @@
        sfo-show-file-operation.
            Move space to display-message.
            String
-               "Operation "   
-                   delimited by size
-               ws-operation   
-                   delimited by size
-               " Status "     
-                   delimited by size
-               ws-file-status 
-                   delimited by size
-               " Record "     
-                   delimited by size
-               ws-record      
-                   delimited by size
-               into display-message
-           end-string.
+               'Operacion: ' DELIMITED BY SIZE
+               ws-operation DELIMITED BY SIZE
+               ' - Status: ' DELIMITED BY SIZE
+               ws-file-status DELIMITED BY SIZE
+               ' - '
+               ws-record DELIMITED BY SIZE
+               INTO display-message
+               ON OVERFLOW
+                   DISPLAY 'Error: mensaje demasiado largo'
+                   END-DISPLAY
+           END-STRING
            Perform sm-show-message thru sm-exit.
        sfo-exit.
            Exit.


### PR DESCRIPTION
## ¿Qué cambió?
- Agregué protección `ON OVERFLOW` al `STRING` del párrafo `sfo-show-file-operation` 
  para evitar desbordes silenciosos si el mensaje supera los 80 caracteres.
- Traduje los literales de inglés a español para mantener consistencia con el 
  resto del programa.
- Probado con `cobc -x -fixed`, ejecuta sin errores.

## ¿Por qué?
El `STRING` sin `ON OVERFLOW` puede causar truncado silencioso o comportamiento 
indefinido si la suma de los campos excede `display-message` (PIC X(80)).
Es una buena práctica recomendada por GnuCOBOL.